### PR TITLE
Fix incorrect filepath usage for global script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 install:
 	ln -s `pwd`/svg-stroke-to-path /usr/local/bin/svg-stroke-to-path
 
-tests: test-basic test-files-with-unusual-filepaths
+tests: test-basic test-files-with-unusual-filepaths test-install
 	@echo
 	@echo "Success! All tests passed."
 	@echo
@@ -19,3 +19,8 @@ test-files-with-unusual-filepaths:
 	./svg-stroke-to-path SameStrokeColor \
 		'stroke="#000"' \
 		test/../test/output\ *.svg
+
+test-install:
+	rm -f test/output.svg
+	cp test/input.svg test/output.svg
+	svg-stroke-to-path SameStrokeColor 'stroke="#000"' test/output.svg

--- a/svg-stroke-to-path
+++ b/svg-stroke-to-path
@@ -36,9 +36,6 @@ if ! [ -x "$(command -v inkscape)" ]; then
   exit 1
 fi
 
-# Hopefully this `realpath` shim works on all platforms 😬
-script_path="$(cd "$(dirname "$0")" && pwd -P)"
-
 # Read the arguments
 select_method=$1
 select_attr=$2
@@ -127,5 +124,5 @@ convert_file() {
 
 for file in "$@"
 do
-    convert_file $select_method "$select_attr" "$script_path/$file"
+    convert_file $select_method "$select_attr" `pwd`"/$file"
 done


### PR DESCRIPTION
This MR addresses issue #4 

The script works fine if one uses it as a non-global script.

But after symlinking the script to be global, and calling the script, the path no longer works.

This MR fixes that by using the `pwd` command, rather than some convoluted dirname function.